### PR TITLE
Filtered dropdown options

### DIFF
--- a/sauti/src/App.js
+++ b/sauti/src/App.js
@@ -14,7 +14,7 @@ const App = () => {
     query: "Sessions"
   });
   const [crossFilter, setCrossFilter] = useState({ 
-    type: "", 
+    type: "age", 
     query: "Users" 
   });
   const [indexLabel, setIndexLabel] = useState(
@@ -64,7 +64,7 @@ const App = () => {
               endDate={endDate}
             />
           </div>
-          <div className="dropdown-container">
+          {/* <div className="dropdown-container">
             <FilterBox
               onChange={onChange}
               onSubmit={onSubmit}
@@ -82,7 +82,7 @@ const App = () => {
               setStartDate={setStartDate}
               setEndDate={setEndDate}
             />
-          </div>
+          </div> */}
         </div>
       </div>
     </div>

--- a/sauti/src/App.js
+++ b/sauti/src/App.js
@@ -68,7 +68,7 @@ const App = () => {
               endDate={endDate}
             />
           </div>
-          {/* <div className="dropdown-container">
+          <div className="dropdown-container">
             <FilterBox
               onChange={onChange}
               onSubmit={onSubmit}
@@ -88,7 +88,7 @@ const App = () => {
               setStartDate={setStartDate}
               setEndDate={setEndDate}
             />
-          </div> */}
+          </div>
         </div>
       </div>
     </div>

--- a/sauti/src/App.scss
+++ b/sauti/src/App.scss
@@ -2,7 +2,6 @@ $greyColor: #4d4f52;
 
 .Graph-Container{
   height:600px;
-  width: 1500px;
 }
 
 .loader-container{

--- a/sauti/src/App.scss
+++ b/sauti/src/App.scss
@@ -2,6 +2,7 @@ $greyColor: #4d4f52;
 
 .Graph-Container{
   height:600px;
+  width: 1500px;
 }
 
 .loader-container{

--- a/sauti/src/Components/FilterBox.js
+++ b/sauti/src/Components/FilterBox.js
@@ -7,7 +7,6 @@ import { FilterBoxOptions } from "./FilterBoxOptions";
 import graphLabels from "./graphLabels";
 
 export default function FilterBox(props) {
-  console.log("checkboxOptions", props.checkboxOptions);
   const [options, setOptions] = useState(FilterBoxOptions.default);
   const [filterBoxIndex, setFilterBoxIndex] = useState({
     type: "request_type",
@@ -33,6 +32,11 @@ export default function FilterBox(props) {
   ] = useState("");
   const [filterBoxStartDate, setFilterBoxStartDate] = useState("2012-01-01");
   const [filterBoxEndDate, setFilterBoxEndDate] = useState("2020-01-08");
+
+  useEffect(() => {
+    setOptions(options.filter(obj => obj.label !== filterBoxIndexLabel));
+    console.log(options)
+  }, [filterBoxIndexLabel])
 
   const handleSubmit = e => {
     e.preventDefault();
@@ -77,6 +81,7 @@ export default function FilterBox(props) {
           onChange={e => {
             setFilterBoxIndex(e.value);
             setFilterBoxIndexLabel(e.label);
+            setOptions(FilterBoxOptions.default)
             ClickTracker(e.value.type);
             if (e.value.arg) {
               setFilterBoxArgForQuery(e.value.arg);
@@ -89,7 +94,7 @@ export default function FilterBox(props) {
           controlClassName="myControlClassName"
           arrowClassName="myArrowClassName"
           className="dropdown"
-          options={options}
+          options={options.filter(obj => obj.label !== setFilterBoxIndexLabel)}
           value={filterBoxCrossLabel}
           placeholder="Select second option..."
           onChange={e => {


### PR DESCRIPTION
Removed the accidental ability to select a crossfilter that is the same as your index value, which resulted in a broken graph. The dropdown options now filter out the index value before displaying in the dropdown menu.